### PR TITLE
Update deploy workflow

### DIFF
--- a/.github/actions/get-release-version/action.yaml
+++ b/.github/actions/get-release-version/action.yaml
@@ -8,15 +8,15 @@ inputs:
     description: 'name or regex pattern to match for the class name to look for'
     default: '.*'
 outputs:
-  current-version:
-    description: 'The current release version'
-    value: ${{ steps.get_current_version.outputs.current-version }}
+  version:
+    description: 'The release version'
+    value: ${{ steps.get_version.outputs.version }}
 runs:
   using: "composite"
   steps:
-    - id: get_current_version
+    - id: get_version
       run: |
-        CURRENT_VERSION=$(grep -Pzo '\\ProvidesClass\{${{ inputs.class-name }}\}(.|\n)*?\[\d{4}-\d{2}-\d{2} v\K\d+\.\d+\.\d+' ${{ inputs.file }} | tr '\0' '\n')
-        echo "found version: $CURRENT_VERSION"
-        echo "current-version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+        VERSION=$(grep -Pzo '\\ProvidesClass\{${{ inputs.class-name }}\}(.|\n)*?\[\d{4}-\d{2}-\d{2} v\K\d+\.\d+\.\d+' ${{ inputs.file }} | tr '\0' '\n')
+        echo "found version: $VERSION"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,13 +1,16 @@
 name: Create release
 
 on:
-  push:
-    tags:
-      - "v*"
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: startsWith(github.event.pull_request.title, 'Release:') && startsWith(github.head_ref, 'release/')
     container: registry.gitlab.com/islandoftex/images/texlive:TL2024-2024-05-19-full
     permissions:
       contents: write
@@ -15,6 +18,12 @@ jobs:
       # Check out the repository
       - name: Checkout repository
         uses: actions/checkout@v4
+      # Set up Git as github-actions bot
+      - name: Set up Git
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
 
       # Run automated testing
       # extract files from dtx
@@ -24,10 +33,25 @@ jobs:
         run: l3build ctan -q -H
         working-directory: ./rub-kunstgeschichte
 
+      # Create tag with the new version
+      - name: Get new version number
+        id: get_new_version
+        uses: ./.github/actions/get-release-version
+        with:
+          file: ./rub-kunstgeschichte/rub-kunstgeschichte.dtx
+          class-name: rub-kunstgeschichte
+      - name: Tag the commit
+        run: |
+          next_version=${{ steps.get_new_version.outputs.version }}
+          git tag -a "$next_version" -m "$Version next_version. See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details."
+          git push --follow-tags
+
       # Create a GitHub release
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.get_new_version.outputs.version }}
+          name: Release ${{ steps.get_new_version.outputs.version }}
           files: |
             rub-kunstgeschichte/build/unpacked/rub-kunstgeschichte.cls
             rub-kunstgeschichte/build/distrib/**/*.zip

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,12 +46,21 @@ jobs:
           git tag -a "$next_version" -m "$Version next_version. See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details."
           git push --follow-tags
 
+      # Extract release notes from CHANGELOG.md
+      - name: Extract release notes
+        id: extract_release_notes
+        run: |
+          RELEASE_NOTES_PATH=${{ github.workspace }}/release_notes.md
+          sed -n '/^## \[${{ steps.get_new_version.outputs.version }}\]/,/^## \[v[0-9]\+\.[0-9]\+\.[0-9]\+\]/ { /^## \[v[0-9]\+\.[0-9]\+\.[0-9]\+\]/ !p; }' CHANGELOG.md > $RELEASE_NOTES_PATH
+          echo "release-notes-path=$RELEASE_NOTES_PATH" >> "$GITHUB_OUTPUT"
+
       # Create a GitHub release
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get_new_version.outputs.version }}
           name: Release ${{ steps.get_new_version.outputs.version }}
+          body_path: ${{ steps.extract_release_notes.outputs.release-notes-path }}
           files: |
             rub-kunstgeschichte/build/unpacked/rub-kunstgeschichte.cls
             rub-kunstgeschichte/build/distrib/**/*.zip

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Extract MAJOR, MINOR and PATCH version numbers
         id: extract_major_minor_patch
         env:
-          VERSION_FULL: ${{ steps.get_current_version.outputs.current-version }}
+          VERSION_FULL: ${{ steps.get_current_version.outputs.version }}
         run: |
           echo "version_major=$(echo $VERSION_FULL | grep -Po '^\d+')" >> "$GITHUB_OUTPUT"
           echo "version_minor=$(echo $VERSION_FULL | grep -Po '^\d+\.\K\d+')" >> "$GITHUB_OUTPUT"
@@ -99,7 +99,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCH: release/${{ steps.calculate_new_version.outputs.new_version }}
           PR_TITLE: "Release: ${{ steps.calculate_new_version.outputs.new_version }} Pull Request"
-          PR_BODY: "This pull request contains the version bump from ${{ steps.get_current_version.outputs.current-version }} to ${{ steps.calculate_new_version.outputs.new_version }}. It was created automatically in the '${{ github.workflow }}' workflow triggered by @${{ github.triggering_actor }}."
+          PR_BODY: "This pull request contains the version bump from ${{ steps.get_current_version.outputs.version }} to ${{ steps.calculate_new_version.outputs.new_version }}. It was created automatically in the '${{ github.workflow }}' workflow triggered by @${{ github.triggering_actor }}."
       # Summarize results
       - name: Summarize job
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+release_notes.md
+
 # compiled files
 out
 


### PR DESCRIPTION
Update the deploy workflow to be triggered by a completed release PR to main branch instead of tag pushes and automatically tag the version during the workflow. Also automatically extract release notes from CHANGELOG.md for the Github release.